### PR TITLE
`#wildcard_mask`/`#to_s_with_prefix` use native method of ipaddr gem v1.2.7+

### DIFF
--- a/lib/ipaddr-ext/extensions.rb
+++ b/lib/ipaddr-ext/extensions.rb
@@ -21,19 +21,20 @@ module IPAddrExt
       end
     end
 
-    # Returns the wildcard mask in string format e.g. 0.0.255.255
-    # ref: https://github.com/ruby/ipaddr/pull/44
-    def wildcard_mask
-      case @family
-      when Socket::AF_INET
-        mask = IPAddr::IN4MASK ^ @mask_addr
-      when Socket::AF_INET6
-        mask = IPAddr::IN6MASK ^ @mask_addr
-      else
-        raise AddressFamilyError, "unsupported address family"
-      end
+    unless defined?(IPAddr::VERSION) && Gem::Version.new(IPAddr::VERSION) >= Gem::Version.new("1.2.7") # Ruby 3.4+ default gem
+      # Returns the wildcard mask in string format e.g. 0.0.255.255
+      def wildcard_mask
+        case @family
+        when Socket::AF_INET
+          mask = IPAddr::IN4MASK ^ @mask_addr
+        when Socket::AF_INET6
+          mask = IPAddr::IN6MASK ^ @mask_addr
+        else
+          raise AddressFamilyError, "unsupported address family"
+        end
 
-      _to_string(mask)
+        _to_string(mask)
+      end
     end
 
     # Returns true if two ipaddrs are equal.
@@ -72,7 +73,11 @@ module IPAddrExt
 
     # Returns the address with prefix
     def to_s_with_prefix
-      "#{self.to_s}/#{prefix}"
+      if defined?(IPAddr::VERSION) && Gem::Version.new(IPAddr::VERSION) >= Gem::Version.new("1.2.7") # Ruby 3.4+ default gem
+        cidr
+      else
+        "#{self.to_s}/#{prefix}"
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
Use a native method of ipaddr gem v1.2.7+ for `#wildcard_mask`/`#to_s_with_prefix`

## Changes
- Use `IPAddr#wildcard_mask` from the IPAddr gem if use ipaddr gem v1.2.7+
- Use `IPAddr#cidr` for `#to_s_with_prefix` if use ipaddr gem v1.2.7+.

## Related URL
- ipaddr gem v1.2.7
  - https://github.com/ruby/ipaddr/releases/tag/v1.2.7
