### PR TITLE
Fix Actionview FormHelper#text_field to add IPAddr prefix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }}
+    name: Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails_version }}
     strategy:
       matrix:
         ruby:
@@ -19,9 +19,13 @@ jobs:
           - '3.1'
           - '3.0'
           - '2.7'
+        rails_version: ['7.2', '7.1', '7.0', '6.1', ''] # '': with out rails (actionview)
+    env:
+      RAILS_VERSION: ${{ matrix.rails_version }}
+      CI: true
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,13 +13,14 @@ jobs:
     name: Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails_version }}
     strategy:
       matrix:
-        ruby:
-          - '3.3'
-          - '3.2'
-          - '3.1'
-          - '3.0'
-          - '2.7'
+        ruby: ['3.3', '3.2', '3.1', '3.0', '2.7']
         rails_version: ['7.2', '7.1', '7.0', '6.1', ''] # '': with out rails (actionview)
+        exclude:
+          # rails 7.2: support ruby 3.1+
+          - ruby: '3.0'
+            rails_version: '7.2'
+          - ruby: '2.7'
+            rails_version: '7.2'
     env:
       RAILS_VERSION: ${{ matrix.rails_version }}
       CI: true

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,14 @@
 source "https://rubygems.org"
 
 gemspec
+
+if ENV['CI'].nil?
+  # for development
+  gem "actionview"
+
+else
+  # for CI
+  unless ENV['RAILS_VERSION'].blank?
+    gem "actionview", "~> #{ENV['RAILS_VERSION']}"
+  end
+end

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ if ENV['CI'].nil?
 
 else
   # for CI
-  unless ENV['RAILS_VERSION'].blank?
+  unless ENV['RAILS_VERSION'].nil? || ENV['RAILS_VERSION'] == ''
     gem "actionview", "~> #{ENV['RAILS_VERSION']}"
   end
 end

--- a/ipaddr-ext.gemspec
+++ b/ipaddr-ext.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake", ">= 13.0"
   spec.add_development_dependency "rspec", ">= 3.0"
+  spec.add_development_dependency "actionview"
 end

--- a/ipaddr-ext.gemspec
+++ b/ipaddr-ext.gemspec
@@ -31,5 +31,4 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake", ">= 13.0"
   spec.add_development_dependency "rspec", ">= 3.0"
-  spec.add_development_dependency "actionview"
 end

--- a/lib/ipaddr-ext.rb
+++ b/lib/ipaddr-ext.rb
@@ -9,4 +9,6 @@ IPAddr.send(:prepend, IPAddrExt::Extensions)
 IPAddrExt::JSON.remove_as_json
 IPAddr.send(:include, IPAddrExt::JSON)
 
-require "ipaddr-ext/actionview/tag_helper"
+if defined?(::ActionView) && ActionView.version >= Gem::Version.new("6.1.0")
+  require "ipaddr-ext/actionview/tag_helper"
+end

--- a/lib/ipaddr-ext.rb
+++ b/lib/ipaddr-ext.rb
@@ -8,3 +8,5 @@ IPAddr.send(:prepend, IPAddrExt::Extensions)
 
 IPAddrExt::JSON.remove_as_json
 IPAddr.send(:include, IPAddrExt::JSON)
+
+require "ipaddr-ext/actionview/tag_helper"

--- a/lib/ipaddr-ext/actionview/tag_helper.rb
+++ b/lib/ipaddr-ext/actionview/tag_helper.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'action_view'
+
+module ActionView
+  module Helpers
+    module TagHelper
+      class TagBuilder
+        # Overwrite to fix FormHelper#text_field build value attribute of IPAddr without prefix
+        # https://github.com/rails/rails/pull/52365
+        def tag_option(key, value, escape)
+          key = ERB::Util.xml_name_escape(key) if escape
+
+          case value
+          when Array, Hash
+            value = TagHelper.build_tag_values(value) if key.to_s == "class"
+            value = escape ? safe_join(value, " ") : value.join(" ")
+          when Regexp
+            value = escape ? ERB::Util.unwrapped_html_escape(value.source) : value.source
+          when IPAddr
+            addr = value.to_s
+            unless (value.ipv4? && value.prefix == 32) || (value.ipv6? && value.prefix == 128)
+              addr = format("%s/%s", value.to_s, value.prefix)
+            end
+
+            value = escape ? ERB::Util.unwrapped_html_escape(addr) : addr
+          else
+            value = escape ? ERB::Util.unwrapped_html_escape(value) : value.to_s
+          end
+          value = value.gsub('"', "&quot;") if value.include?('"')
+
+          %(#{key}="#{value}")
+        end
+      end
+    end
+  end
+end

--- a/spec/ipaddr-ext/actionview/tag_helper_spec.rb
+++ b/spec/ipaddr-ext/actionview/tag_helper_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'action_view'
+
+RSpec.describe "IPAddrExt::ActionView::TagHelper" do
+  include ActionView::Helpers::TagHelper
+
+  context "#tag_option" do
+    it "tag options with ipaddr v4" do
+      addr = IPAddr.new("192.0.2.0")
+
+      expect(tag(:input, value: addr)).to eq "<input value=\"192.0.2.0\" />"
+    end
+
+    it "tag options with ipaddr v4 cidr" do
+      addr = IPAddr.new("192.0.2.0/24")
+
+      expect(tag(:input, value: addr)).to eq "<input value=\"192.0.2.0/24\" />"
+    end
+
+    it "tag options with ipaddr v6" do
+      addr = IPAddr.new("2001:db8::")
+
+      expect(tag(:input, value: addr)).to eq "<input value=\"2001:db8::\" />"
+    end
+
+    it "tag options with ipaddr v6 cidr" do
+      addr = IPAddr.new("2001:db8::/32")
+
+      expect(tag(:input, value: addr)).to eq "<input value=\"2001:db8::/32\" />"
+    end
+  end
+end

--- a/spec/ipaddr-ext/actionview/tag_helper_spec.rb
+++ b/spec/ipaddr-ext/actionview/tag_helper_spec.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
-require 'action_view'
-
 RSpec.describe "IPAddrExt::ActionView::TagHelper" do
-  include ActionView::Helpers::TagHelper
+  begin
+    require 'action_view'
+    include ActionView::Helpers::TagHelper
+  rescue LoadError
+    before do
+      skip 'Does not depend on action_view gem'
+    end
+  end
 
   context "#tag_option" do
     it "tag options with ipaddr v4" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+begin
+  require 'action_view'
+rescue LoadError
+end
+
 require "ipaddr-ext"
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Summary
Overwrite `FormHelper#text_field` of Actionview to add prefix value of IPAddr.

## Changes
- Fix FormHelper#text_field build value attribute of IPAddr without prefix
  - https://github.com/rails/rails/issues/52364
- Add CI matrix for Rails 6.1+

```ruby
require 'action_view'
include ActionView::Helpers::TagHelper

tag(:input, value: IPAddr.new("192.0.2.0/24"))
=> "<input value=\"192.0.2.0/24\" />" # rails/actionview return address without prefix "<input value=\"192.0.2.0\" />"
```
