### PR TITLE
CI: Update for Rails 8.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,15 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.3', '3.2', '3.1', '3.0', '2.7']
-        rails_version: ['7.2', '7.1', '7.0', '6.1', ''] # '': with out rails (actionview)
+        rails_version: ['8.0', '7.2', '7.1', '7.0', '6.1', ''] # '': with out rails (actionview)
         exclude:
+          # rails 8.0: support ruby 3.2+
+          - ruby: '3.1'
+            rails_version: '8.0'
+          - ruby: '3.0'
+            rails_version: '8.0'
+          - ruby: '2.7'
+            rails_version: '8.0'
           # rails 7.2: support ruby 3.1+
           - ruby: '3.0'
             rails_version: '7.2'


### PR DESCRIPTION
## Summary
Update CI for Rails 8.0

## Changes
- Add ci matrix for rails 8.0

## Related URL
- Ruby on Rails — Rails 8.0: No PaaS Required
  - https://rubyonrails.org/2024/11/7/rails-8-no-paas-required
