### PR TITLE
Fix the `uninitialized constant ActionView::Helpers::UrlHelper::URI` error in Rails 7.2.2+ or 7.1.5+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,6 @@ if ENV['CI'].nil?
 else
   # for CI
   unless ENV['RAILS_VERSION'].nil? || ENV['RAILS_VERSION'] == ''
-    gem "actionview", "~> #{ENV['RAILS_VERSION']}"
+    gem "actionview", "~> #{ENV['RAILS_VERSION']}.0"
   end
 end

--- a/lib/ipaddr-ext/actionview/tag_helper.rb
+++ b/lib/ipaddr-ext/actionview/tag_helper.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 require 'action_view'
+if (ActionView.gem_version >= Gem::Version.new('7.2.2') && ActionView.gem_version < Gem::Version.new('8.0')) ||
+   (ActionView.gem_version >= Gem::Version.new('7.1.5') && ActionView.gem_version < Gem::Version.new('7.2'))
+  require 'uri'
+end
 
 module ActionView
   module Helpers


### PR DESCRIPTION
## Summary
Add `require "uri"` only for Rails 7.2.2+ or Rails 7.1.5+ to fix the reference error with the URI class.

The error details are as follows.
```ruby
$ bundle exec rake
/opt/hostedtoolcache/Ruby/3.3.6/x64/bin/ruby -I/home/runner/work/ipaddr-ext/ipaddr-ext/vendor/bundle/ruby/3.3.0/gems/rspec-core-3.13.2/lib:/home/runner/work/ipaddr-ext/ipaddr-ext/vendor/bundle/ruby/3.3.0/gems/rspec-support-3.13.1/lib /home/runner/work/ipaddr-ext/ipaddr-ext/vendor/bundle/ruby/3.3.0/gems/rspec-core-3.13.2/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb

An error occurred while loading spec_helper.
Failure/Error: module Helpers

NameError:
  uninitialized constant ActionView::Helpers::UrlHelper::URI
# ./vendor/bundle/ruby/3.3.0/gems/actionview-7.1.5/lib/action_view/helpers/url_helper.rb:564:in `<module:UrlHelper>'
# ./vendor/bundle/ruby/3.3.0/gems/actionview-7.1.5/lib/action_view/helpers/url_helper.rb:17:in `<module:Helpers>'
# ./vendor/bundle/ruby/3.3.0/gems/actionview-7.1.5/lib/action_view/helpers/url_helper.rb:10:in `<module:ActionView>'
# ./vendor/bundle/ruby/3.3.0/gems/actionview-7.1.5/lib/action_view/helpers/url_helper.rb:9:in `<top (required)>'
# ./vendor/bundle/ruby/3.3.0/gems/actionview-7.1.5/lib/action_view/helpers.rb:7:in `<top (required)>'
# ./lib/ipaddr-ext/actionview/tag_helper.rb:6:in `<module:ActionView>'
# ./lib/ipaddr-ext/actionview/tag_helper.rb:5:in `<top (required)>'
# ./lib/ipaddr-ext.rb:13:in `<top (required)>'
# ./spec/spec_helper.rb:8:in `<top (required)>'
No examples found.
No examples found.


Finished in 0.00004 seconds (files took 0.12916 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples

Finished in 0.00004 seconds (files took 0.12916 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples
```

## Related URL
- #4 
- https://github.com/rails/rails/pull/53164
