### PR TITLE
Add ruby 3.4 to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails_version }}
     strategy:
       matrix:
-        ruby: ['3.3', '3.2', '3.1', '3.0', '2.7']
+        ruby: ['3.4', '3.3', '3.2', '3.1', '3.0', '2.7']
         rails_version: ['8.0', '7.2', '7.1', '7.0', '6.1', ''] # '': with out rails (actionview)
         exclude:
           # rails 8.0: support ruby 3.2+


### PR DESCRIPTION
## Summary
Update the CI matrix for Ruby 3.4.

## Changes
- add ruby 3.4 to CI

## Related URL
- Ruby 3.4.0 Released
  - https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/
