### PR TITLE
Fix CI: Add dependency of concurrent-ruby v1.3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,11 @@ else
   unless ENV['RAILS_VERSION'].nil? || ENV['RAILS_VERSION'] == ''
     gem "actionview", "~> #{ENV['RAILS_VERSION']}.0"
 
+    if ENV['RAILS_VERSION'] == '7.0' || ENV['RAILS_VERSION'] == '6.1'
+      # Fix https://github.com/rails/rails/issues/54260
+      gem "concurrent-ruby", "1.3.4"
+    end
+
     if RUBY_VERSION >= '3.3'
       gem 'mutex_m'
       gem 'base64'


### PR DESCRIPTION
## Summary
Fix CI error of NameError uninitialized constant `ActiveSupport::LoggerThreadSafeLevel::Logger`

## Changes
- Add dependency of concurrent-ruby v1.3.4 for CI

### Error Details
```sh
An error occurred while loading spec_helper.
Failure/Error: require 'action_view'

NameError:
  uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger

      Logger::Severity.constants.each do |severity|
      ^^^^^^
# ./vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.8.7/lib/active_support/logger_thread_safe_level.rb:12:in `<module:LoggerThreadSafeLevel>'
# ./vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.8.7/lib/active_support/logger_thread_safe_level.rb:9:in `<module:ActiveSupport>'
# ./vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.8.7/lib/active_support/logger_thread_safe_level.rb:8:in `<top (required)>'
# ./vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.8.7/lib/active_support/logger_silence.rb:5:in `require'
# ./vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.8.7/lib/active_support/logger_silence.rb:5:in `<top (required)>'
# ./vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.8.7/lib/active_support/logger.rb:3:in `require'
# ./vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.8.7/lib/active_support/logger.rb:3:in `<top (required)>'
# ./vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.8.7/lib/active_support.rb:29:in `require'
# ./vendor/bundle/ruby/3.1.0/gems/activesupport-7.0.8.7/lib/active_support.rb:29:in `<top (required)>'
# ./vendor/bundle/ruby/3.1.0/gems/actionview-7.0.8.7/lib/action_view.rb:26:in `require'
# ./vendor/bundle/ruby/3.1.0/gems/actionview-7.0.8.7/lib/action_view.rb:26:in `<top (required)>'
# ./spec/spec_helper.rb:4:in `require'
# ./spec/spec_helper.rb:4:in `<top (required)>'
No examples found.
No examples found.
```

## Related URL
- https://github.com/rails/rails/issues/54260
