### PR TITLE
CI: Add Ruby 4.0 to CI Matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails_version }}
     strategy:
       matrix:
-        ruby: ['3.4', '3.3', '3.2', '3.1', '3.0', '2.7']
+        ruby: ['4.0', '3.4', '3.3', '3.2', '3.1', '3.0', '2.7']
         rails_version: ['8.1', '8.0', '7.2', '7.1', '7.0', '6.1', ''] # '': with out rails (actionview)
         exclude:
           # rails 8.1: support ruby 3.2+


### PR DESCRIPTION
## Summary
This Pull Request addes Ruby 4.0 to CI Matrix.

## Changes
- add ruby 4.0 to CI

## Related URL
- Ruby 4.0.0 Released | Ruby
  - https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/
