### PR TITLE
Fix inconsistent behavior between `IPAddr.new("0.0.0.0") == nil` and `nil == IPAddr.new("0.0.0.0")`

### DIFF
--- a/lib/ipaddr-ext/extensions.rb
+++ b/lib/ipaddr-ext/extensions.rb
@@ -40,6 +40,12 @@ module IPAddrExt
     # Returns true if two ipaddrs are equal.
     # Overwrite original == method, fixing to compare address with prefix
     def ==(other)
+      # Fix inconsistent behavior between `IPAddr.new("0.0.0.0") == nil` and `nil == IPAddr.new("0.0.0.0")`
+      # https://github.com/ruby/ipaddr/pull/76
+      if other.nil?
+        return false
+      end
+
       other = coerce_other(other)
     rescue
       false

--- a/spec/ipaddr-ext/extensions_spec.rb
+++ b/spec/ipaddr-ext/extensions_spec.rb
@@ -40,6 +40,9 @@ RSpec.describe IPAddrExt::Extensions do
       expect(IPAddr.new("192.168.1.0/24") == IPAddr.new("192.168.1.0/25")).to eq false
       expect(IPAddr.new("192.168.1.0/24") == IPAddr.new("192.168.1.0")).to eq false
       expect(IPAddr.new("192.168.1.0/24") == IPAddr.new("192.168.1.1")).to eq false
+
+      expect(IPAddr.new("0.0.0.0") == nil).to eq false
+      expect(nil == IPAddr.new("0.0.0.0")).to eq false
     end
 
     it "ipv6" do
@@ -50,6 +53,9 @@ RSpec.describe IPAddrExt::Extensions do
       expect(IPAddr.new("3ffe:505:2::/64") == IPAddr.new("3ffe:505:2::/48")).to eq false
       expect(IPAddr.new("3ffe:505:2::/64") == IPAddr.new("3ffe:505:2::")).to eq false
       expect(IPAddr.new("3ffe:505:2::/64") == IPAddr.new("3ffe:505:2::1")).to eq false
+
+      expect(IPAddr.new("::") == nil).to eq false
+      expect(nil == IPAddr.new("::")).to eq false
     end
   end
 


### PR DESCRIPTION
## Summary
This Pull Request fixes inconsistent behavior between `IPAddr.new("0.0.0.0") == nil` and `nil == IPAddr.new("0.0.0.0")`.

This is to verify whether the following Pull Request for the ipaddr gem works in a real Ruby application.
- https://github.com/ruby/ipaddr/pull/76

## Changes
```ruby
# IPv4
IPAddr.new("0.0.0.0") == nil
#=> true # expected false

nil == IPAddr.new('0.0.0.0')
#=> false

IPAddr.new("0.0.0.0").nil?
#=> false

# IPv6
IPAddr.new("::") == nil
#=> true # expected false

nil == IPAddr.new("::")
#=> false

IPAddr.new("::").nil?
#=> false
```

## Related URL
